### PR TITLE
Fix cards stats route ordering

### DIFF
--- a/server.js
+++ b/server.js
@@ -60,8 +60,8 @@ app.use("/media", express.static(path.join(__dirname, "media"), {
 app.use(express.static(path.join(__dirname, "public")));
 
 // API Routes
-app.use("/api/v1/cards", uploadRoutes);
 app.use("/api/v1/cards", cardsRoutes);
+app.use("/api/v1/cards", uploadRoutes);
 app.use("/api/v1/player", playerRoutes);
 app.use("/api/v1", systemRoutes);
 


### PR DESCRIPTION
## Summary
- mount the cards router before the upload router so non-cardId routes like /stats resolve correctly

## Testing
- curl http://localhost:8080/api/v1/cards/stats

------
https://chatgpt.com/codex/tasks/task_e_68ddc6b106dc83209440228a5c914b15