### PR TITLE
Use HOST constant for server binding

### DIFF
--- a/server.js
+++ b/server.js
@@ -79,12 +79,15 @@ app.use((err, req, res, next) => {
 });
 
 // Start server
-app.listen(PORT, "::", () => {
+app.listen(PORT, HOST, () => {
   const localIP = getLocalIP();
-  
+
   console.log(`🎵 MusicBee Backend started:`);
+  console.log(`   Host Bind: ${HOST}:${PORT}`);
   console.log(`   Local:     http://localhost:${PORT}`);
-  console.log(`   Network:   http://${localIP}:${PORT}`);
+  if (localIP) {
+    console.log(`   Network:   http://${localIP}:${PORT}`);
+  }
   
   // Start mDNS
   // startMDNS({ port: PORT, hostname: SERVICE_NAME })


### PR DESCRIPTION
## Summary
- bind the Express server to the HOST environment variable instead of a hard-coded address
- update startup logging to report the configured host binding and only show the network URL when available

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68ddc6b7bc6c83209fbe43138b53b3fa