### PR TITLE
Adjust media static handler to rely on Express content type detection

### DIFF
--- a/server.js
+++ b/server.js
@@ -47,10 +47,10 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 // Static files
-app.use("/media", express.static(path.join(__dirname, "media"), { 
+app.use("/media", express.static(path.join(__dirname, "media"), {
   fallthrough: true,
   setHeaders: (res, path) => {
-    res.set('Content-Type', 'audio/mpeg');
+    res.type(path);
     res.set('Accept-Ranges', 'bytes');
     res.set('Access-Control-Allow-Origin', '*');
   }


### PR DESCRIPTION
## Summary
- use Express's res.type helper when serving files from the /media static handler so the response content type matches the requested file
- keep Accept-Ranges and CORS headers intact for streamed media responses

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddc6bbbfdc8320ae28ee3a5e1c8f0b