### PR TITLE
Add resetCastState helper to clean Chromecast client state

### DIFF
--- a/lib/cast.js
+++ b/lib/cast.js
@@ -10,6 +10,13 @@ let castPlayer = null;
 let isConnected = false;
 let discoveredDevices = new Map();
 
+function resetCastState() {
+  console.log('[CAST] Connection closed, resetting state');
+  isConnected = false;
+  castClient = null;
+  castPlayer = null;
+}
+
 // Stato interno per tracking
 let current = {
   isPlaying: false,
@@ -155,10 +162,12 @@ function startDeviceDiscovery(targetName = null) {
 async function connectToCastDevice(deviceInfo) {
   return new Promise((resolve, reject) => {
     castClient = new Client();
-    
+
     castClient.connect(deviceInfo.host, () => {
       console.log(`[CAST] Connected to ${deviceInfo.name} (${deviceInfo.host})`);
-      
+
+      castClient.on('close', resetCastState);
+
       castClient.launch(DefaultMediaReceiver, (err, player) => {
         if (err) {
           console.error('[CAST] Error launching media receiver:', err);
@@ -168,6 +177,8 @@ async function connectToCastDevice(deviceInfo) {
 
         castPlayer = player;
         isConnected = true;
+
+        castPlayer.on('close', resetCastState);
 
         // Listener per aggiornamenti stato
         player.on('status', (status) => {
@@ -180,15 +191,8 @@ async function connectToCastDevice(deviceInfo) {
 
     castClient.on('error', (err) => {
       console.error('[CAST] Connection error:', err);
-      isConnected = false;
+      resetCastState();
       reject(err);
-    });
-
-    castClient.on('disconnect', () => {
-      console.log('[CAST] Disconnected');
-      isConnected = false;
-      castClient = null;
-      castPlayer = null;
     });
   });
 }
@@ -470,9 +474,7 @@ export async function getStatus() {
 export function disconnect() {
   if (castClient) {
     castClient.close();
-    castClient = null;
-    castPlayer = null;
-    isConnected = false;
+    resetCastState();
     console.log('[CAST] Disconnected manually');
   }
 }


### PR DESCRIPTION
## Summary
- add a reusable `resetCastState` helper to centralize Chromecast teardown logging and cleanup
- register `close` handlers on both the Cast client and player and reuse the helper from error and manual disconnect paths

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddc8fd49e08320b2fd17e6adc1281f