### PR TITLE
Fix dashboard redeclaration errors by scoping Babel scripts

### DIFF
--- a/public/app/App.jsx
+++ b/public/app/App.jsx
@@ -1,521 +1,523 @@
-window.MusicBee = window.MusicBee || {};
+(() => {
+  window.MusicBee = window.MusicBee || {};
 
-const { useState, useEffect, useMemo, useRef, useCallback } = React;
-const { constants, hooks, components, services, utils } = window.MusicBee;
-const { API_BASE, statusBadgeClasses } = constants;
-const { useToast } = hooks;
-const { Toast, StatCard, ProgressBar, ActivityItem, CardItem } = components;
-const { formatAbsolute, formatNumber, formatRelative, sortCardsByLastScan } = utils;
-const {
-  fetchCardsConfig,
-  fetchCardsStatistics,
-  fetchPlayerStatus,
-  playCard,
-  deleteCard,
-  uploadCard
-} = services;
+  const { useState, useEffect, useMemo, useRef, useCallback } = React;
+  const { constants, hooks, components, services, utils } = window.MusicBee;
+  const { API_BASE, statusBadgeClasses } = constants;
+  const { useToast } = hooks;
+  const { Toast, StatCard, ProgressBar, ActivityItem, CardItem } = components;
+  const { formatAbsolute, formatNumber, formatRelative, sortCardsByLastScan } = utils;
+  const {
+    fetchCardsConfig,
+    fetchCardsStatistics,
+    fetchPlayerStatus,
+    playCard,
+    deleteCard,
+    uploadCard
+  } = services;
 
-const App = () => {
-  const [cards, setCards] = useState([]);
-  const [cardsLoading, setCardsLoading] = useState(true);
-  const [cardsError, setCardsError] = useState(null);
+  const App = () => {
+    const [cards, setCards] = useState([]);
+    const [cardsLoading, setCardsLoading] = useState(true);
+    const [cardsError, setCardsError] = useState(null);
 
-  const [stats, setStats] = useState(null);
-  const [statsLoading, setStatsLoading] = useState(true);
-  const [statsError, setStatsError] = useState(null);
-  const [activity, setActivity] = useState([]);
+    const [stats, setStats] = useState(null);
+    const [statsLoading, setStatsLoading] = useState(true);
+    const [statsError, setStatsError] = useState(null);
+    const [activity, setActivity] = useState([]);
 
-  const [player, setPlayer] = useState({
-    badge: 'offline',
-    badgeLabel: 'In attesa',
-    state: '-',
-    title: 'Stato non disponibile',
-    volume: '-',
-    startedAt: '-',
-    source: '-',
-    lastUpdated: null
-  });
-  const [playerLoading, setPlayerLoading] = useState(true);
-
-  const [searchTerm, setSearchTerm] = useState('');
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const [lastUpdatedAt, setLastUpdatedAt] = useState(null);
-
-  const { toast, showToast, hideToast } = useToast();
-
-  const [formCardId, setFormCardId] = useState('');
-  const [formTitle, setFormTitle] = useState('');
-  const [uploading, setUploading] = useState(false);
-  const [highlightCardId, setHighlightCardId] = useState(false);
-
-  const uploadFormRef = useRef(null);
-  const fileInputRef = useRef(null);
-  const cardIdInputRef = useRef(null);
-  const uploadSectionRef = useRef(null);
-  const highlightTimeoutRef = useRef(null);
-
-  useEffect(() => () => {
-    if (highlightTimeoutRef.current) {
-      clearTimeout(highlightTimeoutRef.current);
-    }
-  }, []);
-
-  const loadCards = useCallback(async () => {
-    setCardsLoading(true);
-    setCardsError(null);
-    try {
-      const cardsMap = await fetchCardsConfig();
-      const sorted = sortCardsByLastScan(cardsMap);
-      setCards(sorted);
-    } catch (error) {
-      setCards([]);
-      setCardsError(error.message || 'Impossibile caricare le carte');
-    } finally {
-      setCardsLoading(false);
-    }
-  }, []);
-
-  const loadStatistics = useCallback(async () => {
-    setStatsLoading(true);
-    setStatsError(null);
-    try {
-      const statistics = await fetchCardsStatistics();
-      const totalCards = statistics.totalCards || 0;
-      const configured = statistics.configuredCards || 0;
-      const unknown = statistics.unknownCards || 0;
-      const configuredPercent = totalCards > 0 ? Math.round((configured / totalCards) * 100) : 0;
-      const unknownPercent = totalCards > 0 ? Math.round((unknown / totalCards) * 100) : 0;
-
-      setStats({
-        totalCards,
-        configuredCards: configured,
-        unknownCards: unknown,
-        totalScans: statistics.totalScans || 0,
-        totalPlays: statistics.totalPlays || 0,
-        configuredPercent,
-        unknownPercent,
-        mostUsedCard: statistics.mostUsedCard || null
-      });
-      setActivity(statistics.recentActivity || []);
-    } catch (error) {
-      setStats(null);
-      setActivity([]);
-      setStatsError(error.message || 'Impossibile caricare le statistiche');
-    } finally {
-      setStatsLoading(false);
-    }
-  }, []);
-
-  const loadPlayerStatus = useCallback(async () => {
-    setPlayerLoading(true);
-    try {
-      const status = await fetchPlayerStatus();
-      const connected = Boolean(status.connected);
-      const isPlaying = Boolean(status.isPlaying);
-      const isPaused = Boolean(status.isPaused);
-      const playerState = status.castStatus?.playerState || (isPlaying ? 'PLAYING' : isPaused ? 'PAUSED' : 'IDLE');
-
-      setPlayer({
-        badge: connected ? (isPlaying ? 'online' : 'idle') : 'offline',
-        badgeLabel: connected ? 'Connesso' : 'Disconnesso',
-        state: playerState,
-        title: status.title || 'Nessuna traccia in riproduzione',
-        volume: typeof status.volume === 'number' ? `${Math.round(status.volume * 100)}%` : '-',
-        startedAt: status.startedAt ? formatRelative(status.startedAt) : '-',
-        source: status.src || '-',
-        lastUpdated: new Date()
-      });
-    } catch (error) {
-      setPlayer({
-        badge: 'offline',
-        badgeLabel: 'Errore',
-        state: '-',
-        title: 'Stato non disponibile',
-        volume: '-',
-        startedAt: '-',
-        source: error.message || 'Stato non disponibile',
-        lastUpdated: null
-      });
-    } finally {
-      setPlayerLoading(false);
-    }
-  }, []);
-
-  const refreshDashboard = useCallback(async () => {
-    setIsRefreshing(true);
-    await Promise.all([loadCards(), loadStatistics(), loadPlayerStatus()]);
-    setIsRefreshing(false);
-    setLastUpdatedAt(new Date());
-  }, [loadCards, loadStatistics, loadPlayerStatus]);
-
-  useEffect(() => {
-    refreshDashboard();
-    const interval = setInterval(refreshDashboard, 30000);
-    return () => clearInterval(interval);
-  }, [refreshDashboard]);
-
-  const filteredCards = useMemo(() => {
-    const normalized = searchTerm.trim().toLowerCase();
-    if (!normalized) return cards;
-    return cards.filter((card) =>
-      card.cardId.toLowerCase().includes(normalized) || (card.title || '').toLowerCase().includes(normalized)
-    );
-  }, [cards, searchTerm]);
-
-  const handlePlay = async (cardId) => {
-    try {
-      const result = await playCard(cardId);
-      const playedTitle = result.played?.title || cardId;
-      showToast({ type: 'success', message: `Riproduzione avviata: ${playedTitle}` });
-      loadPlayerStatus();
-    } catch (error) {
-      showToast({ type: 'error', message: `Errore: ${error.message}` });
-    }
-  };
-
-  const handleDelete = async (cardId) => {
-    if (!window.confirm(`Sei sicuro di voler eliminare la carta ${cardId}?`)) {
-      return;
-    }
-    try {
-      await deleteCard(cardId);
-      showToast({ type: 'success', message: `Carta ${cardId} eliminata.` });
-      await loadCards();
-      await loadStatistics();
-    } catch (error) {
-      showToast({ type: 'error', message: `Errore: ${error.message}` });
-    }
-  };
-
-  const handleAssign = (cardId) => {
-    setFormCardId(cardId);
-    setHighlightCardId(true);
-    showToast({ type: 'info', message: `Carta ${cardId} pronta per l'assegnazione. Seleziona il file audio e premi "Carica e configura".` });
-    requestAnimationFrame(() => {
-      if (cardIdInputRef.current) {
-        cardIdInputRef.current.focus({ preventScroll: true });
-      }
-      if (uploadSectionRef.current) {
-        uploadSectionRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      }
+    const [player, setPlayer] = useState({
+      badge: 'offline',
+      badgeLabel: 'In attesa',
+      state: '-',
+      title: 'Stato non disponibile',
+      volume: '-',
+      startedAt: '-',
+      source: '-',
+      lastUpdated: null
     });
-    if (highlightTimeoutRef.current) {
-      clearTimeout(highlightTimeoutRef.current);
-    }
-    highlightTimeoutRef.current = setTimeout(() => setHighlightCardId(false), 1600);
-  };
+    const [playerLoading, setPlayerLoading] = useState(true);
 
-  const handleUpload = async (event) => {
-    event.preventDefault();
-    const audioFile = fileInputRef.current?.files?.[0];
-    const trimmedCardId = formCardId.trim();
-    const trimmedTitle = formTitle.trim();
+    const [searchTerm, setSearchTerm] = useState('');
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const [lastUpdatedAt, setLastUpdatedAt] = useState(null);
 
-    if (!trimmedCardId || !trimmedTitle || !audioFile) {
-      showToast({ type: 'error', message: 'Compila tutti i campi prima di procedere.' });
-      return;
-    }
+    const { toast, showToast, hideToast } = useToast();
 
-    setUploading(true);
-    try {
-      await uploadCard({ cardId: trimmedCardId, title: trimmedTitle, file: audioFile });
-      showToast({ type: 'success', message: `Carta ${trimmedCardId} configurata con successo!` });
-      setFormCardId('');
-      setFormTitle('');
-      if (fileInputRef.current) {
-        fileInputRef.current.value = '';
+    const [formCardId, setFormCardId] = useState('');
+    const [formTitle, setFormTitle] = useState('');
+    const [uploading, setUploading] = useState(false);
+    const [highlightCardId, setHighlightCardId] = useState(false);
+
+    const uploadFormRef = useRef(null);
+    const fileInputRef = useRef(null);
+    const cardIdInputRef = useRef(null);
+    const uploadSectionRef = useRef(null);
+    const highlightTimeoutRef = useRef(null);
+
+    useEffect(() => () => {
+      if (highlightTimeoutRef.current) {
+        clearTimeout(highlightTimeoutRef.current);
       }
-      uploadFormRef.current?.reset();
-      await loadCards();
-      await loadStatistics();
-    } catch (error) {
-      showToast({ type: 'error', message: `Errore di connessione: ${error.message}` });
-    } finally {
-      setUploading(false);
-    }
-  };
+    }, []);
 
-  return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_#1e293b,_#0f172a_35%,_#020617_100%)]">
-      <Toast toast={toast} onClose={hideToast} />
-      <div className="flex min-h-screen backdrop-blur-sm">
-        <aside className="hidden w-72 flex-shrink-0 flex-col gap-8 border-r border-slate-800/40 bg-slate-950/40 p-8 lg:flex">
-          <div className="flex items-center gap-3 text-lg font-semibold">
-            <span className="grid h-11 w-11 place-items-center rounded-2xl bg-sky-500/10 text-sky-300 ring-1 ring-sky-500/40">🎵</span>
-            MusicBee
-          </div>
-          <nav className="space-y-2 text-sm font-medium text-slate-400">
-            <a className="flex items-center gap-3 rounded-2xl border border-slate-800/60 bg-slate-900/60 px-4 py-3 text-slate-100 shadow-soft" href="#top">
-              📊 <span>Dashboard</span>
-            </a>
-            <div className="flex items-center gap-3 rounded-2xl border border-transparent px-4 py-3 transition hover:border-slate-700/70 hover:bg-slate-900/40">
-              📁 <span>Media library</span>
-            </div>
-            <div className="flex items-center gap-3 rounded-2xl border border-transparent px-4 py-3 transition hover:border-slate-700/70 hover:bg-slate-900/40">
-              📡 <span>Cast monitor</span>
-            </div>
-            <div className="flex items-center gap-3 rounded-2xl border border-transparent px-4 py-3 transition hover:border-slate-700/70 hover:bg-slate-900/40">
-              ⚙️ <span>Impostazioni</span>
-            </div>
-          </nav>
-          <div className="mt-auto space-y-3 text-sm text-slate-400/80">
-            <p className="font-semibold text-slate-300">API attiva</p>
-            <p className="break-all rounded-2xl border border-slate-800/60 bg-slate-900/50 p-3 text-xs text-slate-400">{API_BASE}</p>
-            <p className="text-xs text-slate-500">Sincronizzazione automatica ogni 30s.</p>
-          </div>
-        </aside>
+    const loadCards = useCallback(async () => {
+      setCardsLoading(true);
+      setCardsError(null);
+      try {
+        const cardsMap = await fetchCardsConfig();
+        const sorted = sortCardsByLastScan(cardsMap);
+        setCards(sorted);
+      } catch (error) {
+        setCards([]);
+        setCardsError(error.message || 'Impossibile caricare le carte');
+      } finally {
+        setCardsLoading(false);
+      }
+    }, []);
 
-        <main id="top" className="flex-1 space-y-10 px-6 py-10 sm:px-10 lg:px-16">
-          <header className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
-            <div>
-              <h1 className="text-3xl font-semibold tracking-tight text-slate-50">Centro di controllo MusicBee</h1>
-              <p className="mt-2 text-sm text-slate-400">Gestisci le carte RFID, monitora lo stato del player Cast e analizza le metriche principali.</p>
-            </div>
-            <div className="flex flex-wrap items-center gap-3">
-              <span className="rounded-full border border-slate-700/60 px-4 py-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
-                Ultimo aggiornamento: {lastUpdatedAt ? lastUpdatedAt.toLocaleTimeString('it-IT', { hour: '2-digit', minute: '2-digit', second: '2-digit' }) : '--'}
-              </span>
-              <button
-                type="button"
-                onClick={refreshDashboard}
-                disabled={isRefreshing}
-                className="inline-flex items-center gap-2 rounded-full bg-sky-500/90 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-slate-700/70 disabled:text-slate-400"
-              >
-                {isRefreshing ? '⏳ Aggiornamento...' : '🔄 Aggiorna dati'}
-              </button>
-            </div>
-          </header>
+    const loadStatistics = useCallback(async () => {
+      setStatsLoading(true);
+      setStatsError(null);
+      try {
+        const statistics = await fetchCardsStatistics();
+        const totalCards = statistics.totalCards || 0;
+        const configured = statistics.configuredCards || 0;
+        const unknown = statistics.unknownCards || 0;
+        const configuredPercent = totalCards > 0 ? Math.round((configured / totalCards) * 100) : 0;
+        const unknownPercent = totalCards > 0 ? Math.round((unknown / totalCards) * 100) : 0;
 
-          <section className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-            <StatCard
-              label="Carte totali"
-              value={statsLoading ? '—' : formatNumber(stats?.totalCards)}
-              hint={statsError ? 'Statistiche non disponibili' : 'Include carte configurate e in attesa'}
-            />
-            <StatCard
-              label="Carte configurate"
-              value={statsLoading ? '—' : formatNumber(stats?.configuredCards)}
-              hint={statsLoading ? '' : `${stats?.configuredPercent || 0}% del totale`}
-              accent="text-emerald-300"
-            />
-            <StatCard
-              label="Carte da configurare"
-              value={statsLoading ? '—' : formatNumber(stats?.unknownCards)}
-              hint={statsLoading ? '' : `${stats?.unknownPercent || 0}% del totale`}
-              accent="text-amber-300"
-            />
-            <StatCard
-              label="Interazioni rilevate"
-              value={statsLoading ? '—' : formatNumber((stats?.totalScans || 0) + (stats?.totalPlays || 0))}
-              hint={statsLoading ? '' : `${formatNumber(stats?.totalScans)} scan • ${formatNumber(stats?.totalPlays)} play`}
-              accent="text-sky-300"
-            />
-          </section>
+        setStats({
+          totalCards,
+          configuredCards: configured,
+          unknownCards: unknown,
+          totalScans: statistics.totalScans || 0,
+          totalPlays: statistics.totalPlays || 0,
+          configuredPercent,
+          unknownPercent,
+          mostUsedCard: statistics.mostUsedCard || null
+        });
+        setActivity(statistics.recentActivity || []);
+      } catch (error) {
+        setStats(null);
+        setActivity([]);
+        setStatsError(error.message || 'Impossibile caricare le statistiche');
+      } finally {
+        setStatsLoading(false);
+      }
+    }, []);
 
-          <section className="grid gap-6 xl:grid-cols-[2fr_1fr]">
-            <div className="space-y-6">
-              <div ref={uploadSectionRef} className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-card">
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                  <div>
-                    <h2 className="text-xl font-semibold text-slate-100">Configura nuova carta</h2>
-                    <p className="mt-1 text-sm text-slate-400">Associa rapidamente un file audio caricandolo dal tuo dispositivo.</p>
-                  </div>
-                </div>
-                <form ref={uploadFormRef} onSubmit={handleUpload} className="mt-6 grid gap-4 md:grid-cols-2">
-                  <div className="flex flex-col gap-2 md:col-span-1">
-                    <label htmlFor="cardId" className="text-sm font-medium text-slate-300">ID carta</label>
-                    <input
-                      id="cardId"
-                      ref={cardIdInputRef}
-                      type="text"
-                      value={formCardId}
-                      onChange={(event) => setFormCardId(event.target.value)}
-                      placeholder="es. 123456"
-                      className={`w-full rounded-2xl border border-slate-700/70 bg-slate-950/50 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500/40 ${highlightCardId ? 'ring-2 ring-sky-500/60 border-sky-400' : ''}`}
-                    />
-                  </div>
-                  <div className="flex flex-col gap-2 md:col-span-1">
-                    <label htmlFor="title" className="text-sm font-medium text-slate-300">Titolo</label>
-                    <input
-                      id="title"
-                      type="text"
-                      value={formTitle}
-                      onChange={(event) => setFormTitle(event.target.value)}
-                      placeholder="Nome del brano o descrizione"
-                      className="w-full rounded-2xl border border-slate-700/70 bg-slate-950/50 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
-                    />
-                  </div>
-                  <div className="flex flex-col gap-2 md:col-span-2">
-                    <label htmlFor="audio" className="text-sm font-medium text-slate-300">File audio</label>
-                    <input
-                      id="audio"
-                      ref={fileInputRef}
-                      type="file"
-                      accept="audio/*"
-                      className="block w-full cursor-pointer rounded-2xl border border-dashed border-slate-700/60 bg-slate-950/40 px-4 py-5 text-sm text-slate-300 file:mr-4 file:rounded-full file:border-0 file:bg-sky-500/90 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-slate-950 hover:border-sky-500/50"
-                    />
-                  </div>
-                  <div className="md:col-span-2">
-                    <button
-                      type="submit"
-                      disabled={uploading}
-                      className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-sky-500/90 px-6 py-3 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-slate-700/80 disabled:text-slate-400 md:w-auto"
-                    >
-                      {uploading ? '⏳ Caricamento...' : '📤 Carica e configura'}
-                    </button>
-                  </div>
-                </form>
+    const loadPlayerStatus = useCallback(async () => {
+      setPlayerLoading(true);
+      try {
+        const status = await fetchPlayerStatus();
+        const connected = Boolean(status.connected);
+        const isPlaying = Boolean(status.isPlaying);
+        const isPaused = Boolean(status.isPaused);
+        const playerState = status.castStatus?.playerState || (isPlaying ? 'PLAYING' : isPaused ? 'PAUSED' : 'IDLE');
+
+        setPlayer({
+          badge: connected ? (isPlaying ? 'online' : 'idle') : 'offline',
+          badgeLabel: connected ? 'Connesso' : 'Disconnesso',
+          state: playerState,
+          title: status.title || 'Nessuna traccia in riproduzione',
+          volume: typeof status.volume === 'number' ? `${Math.round(status.volume * 100)}%` : '-',
+          startedAt: status.startedAt ? formatRelative(status.startedAt) : '-',
+          source: status.src || '-',
+          lastUpdated: new Date()
+        });
+      } catch (error) {
+        setPlayer({
+          badge: 'offline',
+          badgeLabel: 'Errore',
+          state: '-',
+          title: 'Stato non disponibile',
+          volume: '-',
+          startedAt: '-',
+          source: error.message || 'Stato non disponibile',
+          lastUpdated: null
+        });
+      } finally {
+        setPlayerLoading(false);
+      }
+    }, []);
+
+    const refreshDashboard = useCallback(async () => {
+      setIsRefreshing(true);
+      await Promise.all([loadCards(), loadStatistics(), loadPlayerStatus()]);
+      setIsRefreshing(false);
+      setLastUpdatedAt(new Date());
+    }, [loadCards, loadStatistics, loadPlayerStatus]);
+
+    useEffect(() => {
+      refreshDashboard();
+      const interval = setInterval(refreshDashboard, 30000);
+      return () => clearInterval(interval);
+    }, [refreshDashboard]);
+
+    const filteredCards = useMemo(() => {
+      const normalized = searchTerm.trim().toLowerCase();
+      if (!normalized) return cards;
+      return cards.filter((card) =>
+        card.cardId.toLowerCase().includes(normalized) || (card.title || '').toLowerCase().includes(normalized)
+      );
+    }, [cards, searchTerm]);
+
+    const handlePlay = async (cardId) => {
+      try {
+        const result = await playCard(cardId);
+        const playedTitle = result.played?.title || cardId;
+        showToast({ type: 'success', message: `Riproduzione avviata: ${playedTitle}` });
+        loadPlayerStatus();
+      } catch (error) {
+        showToast({ type: 'error', message: `Errore: ${error.message}` });
+      }
+    };
+
+    const handleDelete = async (cardId) => {
+      if (!window.confirm(`Sei sicuro di voler eliminare la carta ${cardId}?`)) {
+        return;
+      }
+      try {
+        await deleteCard(cardId);
+        showToast({ type: 'success', message: `Carta ${cardId} eliminata.` });
+        await loadCards();
+        await loadStatistics();
+      } catch (error) {
+        showToast({ type: 'error', message: `Errore: ${error.message}` });
+      }
+    };
+
+    const handleAssign = (cardId) => {
+      setFormCardId(cardId);
+      setHighlightCardId(true);
+      showToast({ type: 'info', message: `Carta ${cardId} pronta per l'assegnazione. Seleziona il file audio e premi "Carica e configura".` });
+      requestAnimationFrame(() => {
+        if (cardIdInputRef.current) {
+          cardIdInputRef.current.focus({ preventScroll: true });
+        }
+        if (uploadSectionRef.current) {
+          uploadSectionRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      });
+      if (highlightTimeoutRef.current) {
+        clearTimeout(highlightTimeoutRef.current);
+      }
+      highlightTimeoutRef.current = setTimeout(() => setHighlightCardId(false), 1600);
+    };
+
+    const handleUpload = async (event) => {
+      event.preventDefault();
+      const audioFile = fileInputRef.current?.files?.[0];
+      const trimmedCardId = formCardId.trim();
+      const trimmedTitle = formTitle.trim();
+
+      if (!trimmedCardId || !trimmedTitle || !audioFile) {
+        showToast({ type: 'error', message: 'Compila tutti i campi prima di procedere.' });
+        return;
+      }
+
+      setUploading(true);
+      try {
+        await uploadCard({ cardId: trimmedCardId, title: trimmedTitle, file: audioFile });
+        showToast({ type: 'success', message: `Carta ${trimmedCardId} configurata con successo!` });
+        setFormCardId('');
+        setFormTitle('');
+        if (fileInputRef.current) {
+          fileInputRef.current.value = '';
+        }
+        uploadFormRef.current?.reset();
+        await loadCards();
+        await loadStatistics();
+      } catch (error) {
+        showToast({ type: 'error', message: `Errore di connessione: ${error.message}` });
+      } finally {
+        setUploading(false);
+      }
+    };
+
+    return (
+      <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_#1e293b,_#0f172a_35%,_#020617_100%)]">
+        <Toast toast={toast} onClose={hideToast} />
+        <div className="flex min-h-screen backdrop-blur-sm">
+          <aside className="hidden w-72 flex-shrink-0 flex-col gap-8 border-r border-slate-800/40 bg-slate-950/40 p-8 lg:flex">
+            <div className="flex items-center gap-3 text-lg font-semibold">
+              <span className="grid h-11 w-11 place-items-center rounded-2xl bg-sky-500/10 text-sky-300 ring-1 ring-sky-500/40">🎵</span>
+              MusicBee
+            </div>
+            <nav className="space-y-2 text-sm font-medium text-slate-400">
+              <a className="flex items-center gap-3 rounded-2xl border border-slate-800/60 bg-slate-900/60 px-4 py-3 text-slate-100 shadow-soft" href="#top">
+                📊 <span>Dashboard</span>
+              </a>
+              <div className="flex items-center gap-3 rounded-2xl border border-transparent px-4 py-3 transition hover:border-slate-700/70 hover:bg-slate-900/40">
+                📁 <span>Media library</span>
               </div>
+              <div className="flex items-center gap-3 rounded-2xl border border-transparent px-4 py-3 transition hover:border-slate-700/70 hover:bg-slate-900/40">
+                📡 <span>Cast monitor</span>
+              </div>
+              <div className="flex items-center gap-3 rounded-2xl border border-transparent px-4 py-3 transition hover:border-slate-700/70 hover:bg-slate-900/40">
+                ⚙️ <span>Impostazioni</span>
+              </div>
+            </nav>
+            <div className="mt-auto space-y-3 text-sm text-slate-400/80">
+              <p className="font-semibold text-slate-300">API attiva</p>
+              <p className="break-all rounded-2xl border border-slate-800/60 bg-slate-900/50 p-3 text-xs text-slate-400">{API_BASE}</p>
+              <p className="text-xs text-slate-500">Sincronizzazione automatica ogni 30s.</p>
+            </div>
+          </aside>
 
-              <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-card">
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <h2 className="text-xl font-semibold text-slate-100">Carte configurate</h2>
-                    <p className="mt-1 text-sm text-slate-400">Filtra le carte per titolo o ID, avvia una riproduzione oppure elimina una configurazione.</p>
+          <main id="top" className="flex-1 space-y-10 px-6 py-10 sm:px-10 lg:px-16">
+            <header className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <h1 className="text-3xl font-semibold tracking-tight text-slate-50">Centro di controllo MusicBee</h1>
+                <p className="mt-2 text-sm text-slate-400">Gestisci le carte RFID, monitora lo stato del player Cast e analizza le metriche principali.</p>
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="rounded-full border border-slate-700/60 px-4 py-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
+                  Ultimo aggiornamento: {lastUpdatedAt ? lastUpdatedAt.toLocaleTimeString('it-IT', { hour: '2-digit', minute: '2-digit', second: '2-digit' }) : '--'}
+                </span>
+                <button
+                  type="button"
+                  onClick={refreshDashboard}
+                  disabled={isRefreshing}
+                  className="inline-flex items-center gap-2 rounded-full bg-sky-500/90 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-slate-700/70 disabled:text-slate-400"
+                >
+                  {isRefreshing ? '⏳ Aggiornamento...' : '🔄 Aggiorna dati'}
+                </button>
+              </div>
+            </header>
+
+            <section className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+              <StatCard
+                label="Carte totali"
+                value={statsLoading ? '—' : formatNumber(stats?.totalCards)}
+                hint={statsError ? 'Statistiche non disponibili' : 'Include carte configurate e in attesa'}
+              />
+              <StatCard
+                label="Carte configurate"
+                value={statsLoading ? '—' : formatNumber(stats?.configuredCards)}
+                hint={statsLoading ? '' : `${stats?.configuredPercent || 0}% del totale`}
+                accent="text-emerald-300"
+              />
+              <StatCard
+                label="Carte da configurare"
+                value={statsLoading ? '—' : formatNumber(stats?.unknownCards)}
+                hint={statsLoading ? '' : `${stats?.unknownPercent || 0}% del totale`}
+                accent="text-amber-300"
+              />
+              <StatCard
+                label="Interazioni rilevate"
+                value={statsLoading ? '—' : formatNumber((stats?.totalScans || 0) + (stats?.totalPlays || 0))}
+                hint={statsLoading ? '' : `${formatNumber(stats?.totalScans)} scan • ${formatNumber(stats?.totalPlays)} play`}
+                accent="text-sky-300"
+              />
+            </section>
+
+            <section className="grid gap-6 xl:grid-cols-[2fr_1fr]">
+              <div className="space-y-6">
+                <div ref={uploadSectionRef} className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-card">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <h2 className="text-xl font-semibold text-slate-100">Configura nuova carta</h2>
+                      <p className="mt-1 text-sm text-slate-400">Associa rapidamente un file audio caricandolo dal tuo dispositivo.</p>
+                    </div>
                   </div>
-                  <div className="flex flex-col items-start gap-2 sm:items-end">
-                    <span className="rounded-full border border-slate-700/60 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-slate-400">
-                      {searchTerm ? `${filteredCards.length}/${cards.length} visibili` : `${cards.length} carte totali`}
-                    </span>
-                    {cardsError && (
-                      <span className="text-xs font-semibold text-rose-300">{cardsError}</span>
+                  <form ref={uploadFormRef} onSubmit={handleUpload} className="mt-6 grid gap-4 md:grid-cols-2">
+                    <div className="flex flex-col gap-2 md:col-span-1">
+                      <label htmlFor="cardId" className="text-sm font-medium text-slate-300">ID carta</label>
+                      <input
+                        id="cardId"
+                        ref={cardIdInputRef}
+                        type="text"
+                        value={formCardId}
+                        onChange={(event) => setFormCardId(event.target.value)}
+                        placeholder="es. 123456"
+                        className={`w-full rounded-2xl border border-slate-700/70 bg-slate-950/50 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500/40 ${highlightCardId ? 'ring-2 ring-sky-500/60 border-sky-400' : ''}`}
+                      />
+                    </div>
+                    <div className="flex flex-col gap-2 md:col-span-1">
+                      <label htmlFor="title" className="text-sm font-medium text-slate-300">Titolo</label>
+                      <input
+                        id="title"
+                        type="text"
+                        value={formTitle}
+                        onChange={(event) => setFormTitle(event.target.value)}
+                        placeholder="Nome del brano o descrizione"
+                        className="w-full rounded-2xl border border-slate-700/70 bg-slate-950/50 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-2 md:col-span-2">
+                      <label htmlFor="audio" className="text-sm font-medium text-slate-300">File audio</label>
+                      <input
+                        id="audio"
+                        ref={fileInputRef}
+                        type="file"
+                        accept="audio/*"
+                        className="block w-full cursor-pointer rounded-2xl border border-dashed border-slate-700/60 bg-slate-950/40 px-4 py-5 text-sm text-slate-300 file:mr-4 file:rounded-full file:border-0 file:bg-sky-500/90 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-slate-950 hover:border-sky-500/50"
+                      />
+                    </div>
+                    <div className="md:col-span-2">
+                      <button
+                        type="submit"
+                        disabled={uploading}
+                        className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-sky-500/90 px-6 py-3 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-slate-700/80 disabled:text-slate-400 md:w-auto"
+                      >
+                        {uploading ? '⏳ Caricamento...' : '📤 Carica e configura'}
+                      </button>
+                    </div>
+                  </form>
+                </div>
+
+                <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-card">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h2 className="text-xl font-semibold text-slate-100">Carte configurate</h2>
+                      <p className="mt-1 text-sm text-slate-400">Filtra le carte per titolo o ID, avvia una riproduzione oppure elimina una configurazione.</p>
+                    </div>
+                    <div className="flex flex-col items-start gap-2 sm:items-end">
+                      <span className="rounded-full border border-slate-700/60 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-slate-400">
+                        {searchTerm ? `${filteredCards.length}/${cards.length} visibili` : `${cards.length} carte totali`}
+                      </span>
+                      {cardsError && (
+                        <span className="text-xs font-semibold text-rose-300">{cardsError}</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="mt-5 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="relative w-full sm:max-w-sm">
+                      <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-slate-500">🔍</span>
+                      <input
+                        type="search"
+                        value={searchTerm}
+                        onChange={(event) => setSearchTerm(event.target.value)}
+                        placeholder="Cerca per titolo o ID..."
+                        className="w-full rounded-full border border-slate-700/70 bg-slate-950/50 py-3 pl-10 pr-4 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+                      />
+                    </div>
+                    <span className="text-xs text-slate-500">Aggiornamento automatico ogni 30s</span>
+                  </div>
+
+                  <div className="mt-6">
+                    {cardsLoading ? (
+                      <div className="flex items-center justify-center rounded-3xl border border-slate-800/60 bg-slate-900/50 p-10 text-sm text-slate-400">
+                        Caricamento carte...
+                      </div>
+                    ) : filteredCards.length === 0 ? (
+                      <div className="flex flex-col items-center justify-center gap-2 rounded-3xl border border-slate-800/60 bg-slate-900/50 p-10 text-center text-sm text-slate-400">
+                        <span className="text-lg">📭</span>
+                        Nessuna carta trovata. Carica un nuovo file o modifica il filtro.
+                      </div>
+                    ) : (
+                      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                        {filteredCards.map((card) => (
+                          <CardItem
+                            key={card.cardId}
+                            card={card}
+                            onPlay={handlePlay}
+                            onDelete={handleDelete}
+                            onAssign={handleAssign}
+                          />
+                        ))}
+                      </div>
                     )}
                   </div>
                 </div>
-                <div className="mt-5 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="relative w-full sm:max-w-sm">
-                    <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-slate-500">🔍</span>
-                    <input
-                      type="search"
-                      value={searchTerm}
-                      onChange={(event) => setSearchTerm(event.target.value)}
-                      placeholder="Cerca per titolo o ID..."
-                      className="w-full rounded-full border border-slate-700/70 bg-slate-950/50 py-3 pl-10 pr-4 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+              </div>
+
+              <aside className="space-y-6">
+                <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-card">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h2 className="text-xl font-semibold text-slate-100">Stato player Cast</h2>
+                      <p className="mt-1 text-sm text-slate-400">Monitora la connessione e i dettagli dell'ultimo contenuto.</p>
+                    </div>
+                    <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wider ${statusBadgeClasses[player.badge] || statusBadgeClasses.offline}`}>
+                      {player.badgeLabel}
+                    </span>
+                  </div>
+                  <div className="mt-6 space-y-4 text-sm text-slate-300">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-slate-500">Stato</p>
+                      <p className="mt-1 text-lg font-semibold text-slate-100">{player.state}{playerLoading ? ' · caricamento' : ''}</p>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-slate-500">Titolo</p>
+                      <p className="mt-1 text-base text-slate-100">{player.title}</p>
+                    </div>
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-slate-500">Volume</p>
+                        <p className="mt-1 font-semibold text-slate-100">{player.volume}</p>
+                      </div>
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-slate-500">Avviato</p>
+                        <p className="mt-1 font-semibold text-slate-100">{player.startedAt}</p>
+                      </div>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-slate-500">Sorgente</p>
+                      <p className="mt-1 break-words text-slate-100">{player.source}</p>
+                    </div>
+                  </div>
+                  <p className="mt-6 text-xs text-slate-500">
+                    Ultimo aggiornamento: {player.lastUpdated ? formatAbsolute(player.lastUpdated) : '--'}
+                  </p>
+                </div>
+
+                <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-card">
+                  <h2 className="text-xl font-semibold text-slate-100">Attività recente</h2>
+                  <p className="mt-1 text-sm text-slate-400">Gli ultimi eventi di scansione o riproduzione registrati dal sistema.</p>
+                  <div className="mt-6 space-y-4">
+                    {activity.length === 0 ? (
+                      <div className="rounded-2xl border border-slate-800/60 bg-slate-900/40 p-6 text-center text-sm text-slate-400">
+                        Nessuna attività registrata negli ultimi eventi.
+                      </div>
+                    ) : (
+                      <ul className="space-y-3">
+                        {activity.map((item, index) => (
+                          <ActivityItem key={`${item.cardId}-${index}`} item={item} />
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                </div>
+
+                <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-card">
+                  <h2 className="text-xl font-semibold text-slate-100">Dettagli utilizzo carte</h2>
+                  <p className="mt-1 text-sm text-slate-400">Analisi rapida della distribuzione tra carte configurate e da configurare.</p>
+                  <div className="mt-6 space-y-5">
+                    <ProgressBar
+                      label="Carte configurate"
+                      value={statsLoading ? '--' : `${formatNumber(stats?.configuredCards)} (${stats?.configuredPercent || 0}%)`}
+                      percent={stats?.configuredPercent || 0}
+                      gradient="linear-gradient(135deg, rgba(34,197,94,0.85), rgba(56,189,248,0.85))"
                     />
-                  </div>
-                  <span className="text-xs text-slate-500">Aggiornamento automatico ogni 30s</span>
-                </div>
-
-                <div className="mt-6">
-                  {cardsLoading ? (
-                    <div className="flex items-center justify-center rounded-3xl border border-slate-800/60 bg-slate-900/50 p-10 text-sm text-slate-400">
-                      Caricamento carte...
-                    </div>
-                  ) : filteredCards.length === 0 ? (
-                    <div className="flex flex-col items-center justify-center gap-2 rounded-3xl border border-slate-800/60 bg-slate-900/50 p-10 text-center text-sm text-slate-400">
-                      <span className="text-lg">📭</span>
-                      Nessuna carta trovata. Carica un nuovo file o modifica il filtro.
-                    </div>
-                  ) : (
-                    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                      {filteredCards.map((card) => (
-                        <CardItem
-                          key={card.cardId}
-                          card={card}
-                          onPlay={handlePlay}
-                          onDelete={handleDelete}
-                          onAssign={handleAssign}
-                        />
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            <aside className="space-y-6">
-              <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-card">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <h2 className="text-xl font-semibold text-slate-100">Stato player Cast</h2>
-                    <p className="mt-1 text-sm text-slate-400">Monitora la connessione e i dettagli dell'ultimo contenuto.</p>
-                  </div>
-                  <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wider ${statusBadgeClasses[player.badge] || statusBadgeClasses.offline}`}>
-                    {player.badgeLabel}
-                  </span>
-                </div>
-                <div className="mt-6 space-y-4 text-sm text-slate-300">
-                  <div>
-                    <p className="text-xs uppercase tracking-wide text-slate-500">Stato</p>
-                    <p className="mt-1 text-lg font-semibold text-slate-100">{player.state}{playerLoading ? ' · caricamento' : ''}</p>
-                  </div>
-                  <div>
-                    <p className="text-xs uppercase tracking-wide text-slate-500">Titolo</p>
-                    <p className="mt-1 text-base text-slate-100">{player.title}</p>
-                  </div>
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <p className="text-xs uppercase tracking-wide text-slate-500">Volume</p>
-                      <p className="mt-1 font-semibold text-slate-100">{player.volume}</p>
-                    </div>
-                    <div>
-                      <p className="text-xs uppercase tracking-wide text-slate-500">Avviato</p>
-                      <p className="mt-1 font-semibold text-slate-100">{player.startedAt}</p>
+                    <ProgressBar
+                      label="Carte da configurare"
+                      value={statsLoading ? '--' : `${formatNumber(stats?.unknownCards)} (${stats?.unknownPercent || 0}%)`}
+                      percent={stats?.unknownPercent || 0}
+                      gradient="linear-gradient(135deg, rgba(245,158,11,0.85), rgba(248,113,113,0.85))"
+                    />
+                    <div className="rounded-2xl border border-slate-800/60 bg-slate-900/40 p-4">
+                      <p className="text-xs uppercase tracking-wide text-slate-500">Top card</p>
+                      <p className="mt-2 text-sm font-semibold text-slate-100">
+                        {stats?.mostUsedCard ? (stats.mostUsedCard.title || stats.mostUsedCard.cardId) : '--'}
+                      </p>
+                      <p className="mt-1 text-xs text-slate-400">
+                        {stats?.mostUsedCard
+                          ? `ID ${stats.mostUsedCard.cardId} • ${formatNumber(stats.mostUsedCard.scanCount || 0)} scan • ${formatNumber(stats.mostUsedCard.playCount || 0)} play`
+                          : 'Nessun dato disponibile.'}
+                      </p>
                     </div>
                   </div>
-                  <div>
-                    <p className="text-xs uppercase tracking-wide text-slate-500">Sorgente</p>
-                    <p className="mt-1 break-words text-slate-100">{player.source}</p>
-                  </div>
                 </div>
-                <p className="mt-6 text-xs text-slate-500">
-                  Ultimo aggiornamento: {player.lastUpdated ? formatAbsolute(player.lastUpdated) : '--'}
-                </p>
-              </div>
-
-              <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-card">
-                <h2 className="text-xl font-semibold text-slate-100">Attività recente</h2>
-                <p className="mt-1 text-sm text-slate-400">Gli ultimi eventi di scansione o riproduzione registrati dal sistema.</p>
-                <div className="mt-6 space-y-4">
-                  {activity.length === 0 ? (
-                    <div className="rounded-2xl border border-slate-800/60 bg-slate-900/40 p-6 text-center text-sm text-slate-400">
-                      Nessuna attività registrata negli ultimi eventi.
-                    </div>
-                  ) : (
-                    <ul className="space-y-3">
-                      {activity.map((item, index) => (
-                        <ActivityItem key={`${item.cardId}-${index}`} item={item} />
-                      ))}
-                    </ul>
-                  )}
-                </div>
-              </div>
-
-              <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-card">
-                <h2 className="text-xl font-semibold text-slate-100">Dettagli utilizzo carte</h2>
-                <p className="mt-1 text-sm text-slate-400">Analisi rapida della distribuzione tra carte configurate e da configurare.</p>
-                <div className="mt-6 space-y-5">
-                  <ProgressBar
-                    label="Carte configurate"
-                    value={statsLoading ? '--' : `${formatNumber(stats?.configuredCards)} (${stats?.configuredPercent || 0}%)`}
-                    percent={stats?.configuredPercent || 0}
-                    gradient="linear-gradient(135deg, rgba(34,197,94,0.85), rgba(56,189,248,0.85))"
-                  />
-                  <ProgressBar
-                    label="Carte da configurare"
-                    value={statsLoading ? '--' : `${formatNumber(stats?.unknownCards)} (${stats?.unknownPercent || 0}%)`}
-                    percent={stats?.unknownPercent || 0}
-                    gradient="linear-gradient(135deg, rgba(245,158,11,0.85), rgba(248,113,113,0.85))"
-                  />
-                  <div className="rounded-2xl border border-slate-800/60 bg-slate-900/40 p-4">
-                    <p className="text-xs uppercase tracking-wide text-slate-500">Top card</p>
-                    <p className="mt-2 text-sm font-semibold text-slate-100">
-                      {stats?.mostUsedCard ? (stats.mostUsedCard.title || stats.mostUsedCard.cardId) : '--'}
-                    </p>
-                    <p className="mt-1 text-xs text-slate-400">
-                      {stats?.mostUsedCard
-                        ? `ID ${stats.mostUsedCard.cardId} • ${formatNumber(stats.mostUsedCard.scanCount || 0)} scan • ${formatNumber(stats.mostUsedCard.playCount || 0)} play`
-                        : 'Nessun dato disponibile.'}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </aside>
-          </section>
-        </main>
+              </aside>
+            </section>
+          </main>
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  };
 
-window.MusicBee.App = App;
+  window.MusicBee.App = App;
+})();

--- a/public/app/components/ActivityItem.jsx
+++ b/public/app/components/ActivityItem.jsx
@@ -1,30 +1,32 @@
-window.MusicBee = window.MusicBee || {};
-window.MusicBee.components = window.MusicBee.components || {};
+(() => {
+  window.MusicBee = window.MusicBee || {};
+  window.MusicBee.components = window.MusicBee.components || {};
 
-const { formatRelative } = window.MusicBee.utils;
+  const { formatRelative } = window.MusicBee.utils;
 
-const ActivityItem = ({ item }) => {
-  const icon = item.action === 'play' ? '🎧' : '📡';
-  const badgeClass = item.type === 'unknown'
-    ? 'bg-amber-500/15 text-amber-200 border border-amber-400/40'
-    : 'bg-sky-500/15 text-sky-100 border border-sky-500/30';
-  const actionLabel = item.action === 'play' ? 'Riproduzione' : 'Scan';
+  const ActivityItem = ({ item }) => {
+    const icon = item.action === 'play' ? '🎧' : '📡';
+    const badgeClass = item.type === 'unknown'
+      ? 'bg-amber-500/15 text-amber-200 border border-amber-400/40'
+      : 'bg-sky-500/15 text-sky-100 border border-sky-500/30';
+    const actionLabel = item.action === 'play' ? 'Riproduzione' : 'Scan';
 
-  return (
-    <li className="flex items-center gap-4 rounded-2xl border border-slate-800/60 bg-slate-900/50 p-4">
-      <span className="text-xl">{icon}</span>
-      <div className="flex-1">
-        <p className="font-semibold text-slate-100">{item.title || item.cardId}</p>
-        <div className="mt-1 flex flex-wrap gap-3 text-xs text-slate-400">
-          <span>ID: {item.cardId}</span>
-          <span>{formatRelative(item.timestamp)}</span>
+    return (
+      <li className="flex items-center gap-4 rounded-2xl border border-slate-800/60 bg-slate-900/50 p-4">
+        <span className="text-xl">{icon}</span>
+        <div className="flex-1">
+          <p className="font-semibold text-slate-100">{item.title || item.cardId}</p>
+          <div className="mt-1 flex flex-wrap gap-3 text-xs text-slate-400">
+            <span>ID: {item.cardId}</span>
+            <span>{formatRelative(item.timestamp)}</span>
+          </div>
         </div>
-      </div>
-      <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${badgeClass}`}>
-        {actionLabel}
-      </span>
-    </li>
-  );
-};
+        <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${badgeClass}`}>
+          {actionLabel}
+        </span>
+      </li>
+    );
+  };
 
-window.MusicBee.components.ActivityItem = ActivityItem;
+  window.MusicBee.components.ActivityItem = ActivityItem;
+})();

--- a/public/app/components/CardItem.jsx
+++ b/public/app/components/CardItem.jsx
@@ -1,83 +1,85 @@
-window.MusicBee = window.MusicBee || {};
-window.MusicBee.components = window.MusicBee.components || {};
+(() => {
+  window.MusicBee = window.MusicBee || {};
+  window.MusicBee.components = window.MusicBee.components || {};
 
-const { formatNumber, formatRelative } = window.MusicBee.utils;
+  const { formatNumber, formatRelative } = window.MusicBee.utils;
 
-const CardItem = ({ card, onPlay, onDelete, onAssign }) => {
-  const usage = card.usage || {};
-  const scanCount = usage.scanCount || 0;
-  const playCount = usage.playCount || 0;
-  const isUnknown = card.type === 'unknown';
-  const hasSource = Boolean(card.source);
-  const canPlay = hasSource && !isUnknown;
-  const chipClass = isUnknown
-    ? 'bg-amber-500/15 text-amber-200 border border-amber-400/40'
-    : 'bg-sky-500/15 text-sky-100 border border-sky-500/30';
+  const CardItem = ({ card, onPlay, onDelete, onAssign }) => {
+    const usage = card.usage || {};
+    const scanCount = usage.scanCount || 0;
+    const playCount = usage.playCount || 0;
+    const isUnknown = card.type === 'unknown';
+    const hasSource = Boolean(card.source);
+    const canPlay = hasSource && !isUnknown;
+    const chipClass = isUnknown
+      ? 'bg-amber-500/15 text-amber-200 border border-amber-400/40'
+      : 'bg-sky-500/15 text-sky-100 border border-sky-500/30';
 
-  return (
-    <article className={`flex flex-col gap-4 rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-soft transition hover:border-sky-500/40 hover:shadow-card ${isUnknown ? 'ring-1 ring-amber-500/30' : ''}`}>
-      <div className="flex items-center justify-between">
-        <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wider ${chipClass}`}>
-          ID {card.cardId}
-        </span>
-        <span className="text-xs font-medium text-slate-400">{isUnknown ? 'Non configurata' : (card.type || '–')}</span>
-      </div>
-
-      <div>
-        <h3 className="text-lg font-semibold text-slate-100">{card.title || `Carta ${card.cardId}`}</h3>
-        <p className="mt-1 text-sm text-slate-400">
-          {hasSource ? 'File associato' : 'Nessun file associato'}
-        </p>
-        {hasSource && (
-          <p className="mt-1 truncate text-sm text-slate-300" title={card.source}>{card.source}</p>
-        )}
-      </div>
-
-      <dl className="grid grid-cols-2 gap-3 text-sm text-slate-300">
-        <div className="rounded-2xl border border-slate-800/50 bg-slate-900/40 p-3">
-          <dt className="text-xs uppercase tracking-wide text-slate-500">Scan</dt>
-          <dd className="mt-1 text-slate-100">{formatNumber(scanCount)}</dd>
+    return (
+      <article className={`flex flex-col gap-4 rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-soft transition hover:border-sky-500/40 hover:shadow-card ${isUnknown ? 'ring-1 ring-amber-500/30' : ''}`}>
+        <div className="flex items-center justify-between">
+          <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wider ${chipClass}`}>
+            ID {card.cardId}
+          </span>
+          <span className="text-xs font-medium text-slate-400">{isUnknown ? 'Non configurata' : (card.type || '–')}</span>
         </div>
-        <div className="rounded-2xl border border-slate-800/50 bg-slate-900/40 p-3">
-          <dt className="text-xs uppercase tracking-wide text-slate-500">Riproduzioni</dt>
-          <dd className="mt-1 text-slate-100">{formatNumber(playCount)}</dd>
-        </div>
-        <div className="rounded-2xl border border-slate-800/50 bg-slate-900/40 p-3 col-span-2">
-          <dt className="text-xs uppercase tracking-wide text-slate-500">Ultimo scan</dt>
-          <dd className="mt-1 text-slate-100">{usage.lastScannedAt ? formatRelative(usage.lastScannedAt) : 'Mai scansionata'}</dd>
-        </div>
-        <div className="rounded-2xl border border-slate-800/50 bg-slate-900/40 p-3 col-span-2">
-          <dt className="text-xs uppercase tracking-wide text-slate-500">Ultima riproduzione</dt>
-          <dd className="mt-1 text-slate-100">{usage.lastPlayedAt ? formatRelative(usage.lastPlayedAt) : 'Mai riprodotta'}</dd>
-        </div>
-      </dl>
 
-      <div className="mt-auto flex flex-wrap gap-3">
-        <button
-          type="button"
-          onClick={() => onPlay(card.cardId)}
-          disabled={!canPlay}
-          className="inline-flex items-center justify-center gap-2 rounded-full bg-sky-500/90 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-slate-700/80 disabled:text-slate-400"
-        >
-          ▶️ Riproduci
-        </button>
-        <button
-          type="button"
-          onClick={() => onAssign(card.cardId)}
-          className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-700/70 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-sky-400 hover:text-sky-300"
-        >
-          📎 Associa file
-        </button>
-        <button
-          type="button"
-          onClick={() => onDelete(card.cardId)}
-          className="ml-auto inline-flex items-center justify-center gap-2 rounded-full bg-rose-500/90 px-4 py-2 text-sm font-semibold text-rose-50 transition hover:bg-rose-400"
-        >
-          🗑️ Elimina
-        </button>
-      </div>
-    </article>
-  );
-};
+        <div>
+          <h3 className="text-lg font-semibold text-slate-100">{card.title || `Carta ${card.cardId}`}</h3>
+          <p className="mt-1 text-sm text-slate-400">
+            {hasSource ? 'File associato' : 'Nessun file associato'}
+          </p>
+          {hasSource && (
+            <p className="mt-1 truncate text-sm text-slate-300" title={card.source}>{card.source}</p>
+          )}
+        </div>
 
-window.MusicBee.components.CardItem = CardItem;
+        <dl className="grid grid-cols-2 gap-3 text-sm text-slate-300">
+          <div className="rounded-2xl border border-slate-800/50 bg-slate-900/40 p-3">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Scan</dt>
+            <dd className="mt-1 text-slate-100">{formatNumber(scanCount)}</dd>
+          </div>
+          <div className="rounded-2xl border border-slate-800/50 bg-slate-900/40 p-3">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Riproduzioni</dt>
+            <dd className="mt-1 text-slate-100">{formatNumber(playCount)}</dd>
+          </div>
+          <div className="rounded-2xl border border-slate-800/50 bg-slate-900/40 p-3 col-span-2">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Ultimo scan</dt>
+            <dd className="mt-1 text-slate-100">{usage.lastScannedAt ? formatRelative(usage.lastScannedAt) : 'Mai scansionata'}</dd>
+          </div>
+          <div className="rounded-2xl border border-slate-800/50 bg-slate-900/40 p-3 col-span-2">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Ultima riproduzione</dt>
+            <dd className="mt-1 text-slate-100">{usage.lastPlayedAt ? formatRelative(usage.lastPlayedAt) : 'Mai riprodotta'}</dd>
+          </div>
+        </dl>
+
+        <div className="mt-auto flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={() => onPlay(card.cardId)}
+            disabled={!canPlay}
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-sky-500/90 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-slate-700/80 disabled:text-slate-400"
+          >
+            ▶️ Riproduci
+          </button>
+          <button
+            type="button"
+            onClick={() => onAssign(card.cardId)}
+            className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-700/70 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-sky-400 hover:text-sky-300"
+          >
+            📎 Associa file
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(card.cardId)}
+            className="ml-auto inline-flex items-center justify-center gap-2 rounded-full bg-rose-500/90 px-4 py-2 text-sm font-semibold text-rose-50 transition hover:bg-rose-400"
+          >
+            🗑️ Elimina
+          </button>
+        </div>
+      </article>
+    );
+  };
+
+  window.MusicBee.components.CardItem = CardItem;
+})();

--- a/public/app/components/ProgressBar.jsx
+++ b/public/app/components/ProgressBar.jsx
@@ -1,19 +1,21 @@
-window.MusicBee = window.MusicBee || {};
-window.MusicBee.components = window.MusicBee.components || {};
+(() => {
+  window.MusicBee = window.MusicBee || {};
+  window.MusicBee.components = window.MusicBee.components || {};
 
-const ProgressBar = ({ label, value, percent, gradient }) => (
-  <div className="space-y-3">
-    <div className="flex items-center justify-between text-sm text-slate-300">
-      <span>{label}</span>
-      <span className="font-semibold text-slate-100">{value}</span>
+  const ProgressBar = ({ label, value, percent, gradient }) => (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between text-sm text-slate-300">
+        <span>{label}</span>
+        <span className="font-semibold text-slate-100">{value}</span>
+      </div>
+      <div className="h-2 w-full rounded-full bg-slate-800/80">
+        <div
+          className="h-full rounded-full transition-all duration-500"
+          style={{ width: `${Math.min(100, Math.max(0, percent))}%`, background: gradient }}
+        />
+      </div>
     </div>
-    <div className="h-2 w-full rounded-full bg-slate-800/80">
-      <div
-        className="h-full rounded-full transition-all duration-500"
-        style={{ width: `${Math.min(100, Math.max(0, percent))}%`, background: gradient }}
-      />
-    </div>
-  </div>
-);
+  );
 
-window.MusicBee.components.ProgressBar = ProgressBar;
+  window.MusicBee.components.ProgressBar = ProgressBar;
+})();

--- a/public/app/components/StatCard.jsx
+++ b/public/app/components/StatCard.jsx
@@ -1,12 +1,14 @@
-window.MusicBee = window.MusicBee || {};
-window.MusicBee.components = window.MusicBee.components || {};
+(() => {
+  window.MusicBee = window.MusicBee || {};
+  window.MusicBee.components = window.MusicBee.components || {};
 
-const StatCard = ({ label, value, hint, accent }) => (
-  <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-card backdrop-blur">
-    <p className="text-sm font-medium text-slate-400">{label}</p>
-    <p className={`mt-2 text-3xl font-semibold ${accent || 'text-slate-100'}`}>{value}</p>
-    {hint && <p className="mt-3 text-xs font-medium uppercase tracking-wider text-slate-500">{hint}</p>}
-  </div>
-);
+  const StatCard = ({ label, value, hint, accent }) => (
+    <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-card backdrop-blur">
+      <p className="text-sm font-medium text-slate-400">{label}</p>
+      <p className={`mt-2 text-3xl font-semibold ${accent || 'text-slate-100'}`}>{value}</p>
+      {hint && <p className="mt-3 text-xs font-medium uppercase tracking-wider text-slate-500">{hint}</p>}
+    </div>
+  );
 
-window.MusicBee.components.StatCard = StatCard;
+  window.MusicBee.components.StatCard = StatCard;
+})();

--- a/public/app/components/Toast.jsx
+++ b/public/app/components/Toast.jsx
@@ -1,27 +1,29 @@
-window.MusicBee = window.MusicBee || {};
-window.MusicBee.components = window.MusicBee.components || {};
+(() => {
+  window.MusicBee = window.MusicBee || {};
+  window.MusicBee.components = window.MusicBee.components || {};
 
-const { toastStyles } = window.MusicBee.constants;
+  const { toastStyles } = window.MusicBee.constants;
 
-const Toast = ({ toast, onClose }) => {
-  if (!toast) return null;
+  const Toast = ({ toast, onClose }) => {
+    if (!toast) return null;
 
-  return (
-    <div className="fixed inset-x-0 top-6 z-50 flex justify-center px-4">
-      <div className={`max-w-xl w-full rounded-3xl border px-5 py-4 text-sm font-medium backdrop-blur ${toastStyles[toast.type] || toastStyles.info}`}>
-        <div className="flex items-start justify-between gap-4">
-          <span>{toast.message}</span>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-xs uppercase tracking-wide text-slate-300/70 hover:text-slate-100"
-          >
-            Chiudi
-          </button>
+    return (
+      <div className="fixed inset-x-0 top-6 z-50 flex justify-center px-4">
+        <div className={`max-w-xl w-full rounded-3xl border px-5 py-4 text-sm font-medium backdrop-blur ${toastStyles[toast.type] || toastStyles.info}`}>
+          <div className="flex items-start justify-between gap-4">
+            <span>{toast.message}</span>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-xs uppercase tracking-wide text-slate-300/70 hover:text-slate-100"
+            >
+              Chiudi
+            </button>
+          </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  };
 
-window.MusicBee.components.Toast = Toast;
+  window.MusicBee.components.Toast = Toast;
+})();

--- a/public/app/constants.js
+++ b/public/app/constants.js
@@ -1,19 +1,21 @@
-window.MusicBee = window.MusicBee || {};
+(() => {
+  window.MusicBee = window.MusicBee || {};
 
-const API_BASE = `${window.location.origin}/api/v1`;
-const statusBadgeClasses = {
-  online: 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/40',
-  idle: 'bg-amber-400/15 text-amber-200 border border-amber-500/30',
-  offline: 'bg-rose-500/15 text-rose-200 border border-rose-500/40'
-};
-const toastStyles = {
-  success: 'border-emerald-500/50 bg-emerald-500/15 text-emerald-100 shadow-soft',
-  error: 'border-rose-500/60 bg-rose-500/20 text-rose-100 shadow-soft',
-  info: 'border-sky-500/50 bg-sky-500/15 text-sky-100 shadow-soft'
-};
+  const API_BASE = `${window.location.origin}/api/v1`;
+  const statusBadgeClasses = {
+    online: 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/40',
+    idle: 'bg-amber-400/15 text-amber-200 border border-amber-500/30',
+    offline: 'bg-rose-500/15 text-rose-200 border border-rose-500/40'
+  };
+  const toastStyles = {
+    success: 'border-emerald-500/50 bg-emerald-500/15 text-emerald-100 shadow-soft',
+    error: 'border-rose-500/60 bg-rose-500/20 text-rose-100 shadow-soft',
+    info: 'border-sky-500/50 bg-sky-500/15 text-sky-100 shadow-soft'
+  };
 
-window.MusicBee.constants = {
-  API_BASE,
-  statusBadgeClasses,
-  toastStyles
-};
+  window.MusicBee.constants = {
+    API_BASE,
+    statusBadgeClasses,
+    toastStyles
+  };
+})();

--- a/public/app/hooks/useToast.js
+++ b/public/app/hooks/useToast.js
@@ -1,33 +1,35 @@
-window.MusicBee = window.MusicBee || {};
-window.MusicBee.hooks = window.MusicBee.hooks || {};
+(() => {
+  window.MusicBee = window.MusicBee || {};
+  window.MusicBee.hooks = window.MusicBee.hooks || {};
 
-const { useState, useEffect, useCallback } = React;
-const DEFAULT_TIMEOUT = 5000;
+  const { useState, useEffect, useCallback } = React;
+  const DEFAULT_TIMEOUT = 5000;
 
-const normalizeToast = (value) => {
-  if (!value) return null;
-  if (typeof value === 'string') {
-    return { type: 'info', message: value };
-  }
-  return value;
-};
+  const normalizeToast = (value) => {
+    if (!value) return null;
+    if (typeof value === 'string') {
+      return { type: 'info', message: value };
+    }
+    return value;
+  };
 
-const useToast = () => {
-  const [toast, setToast] = useState(null);
+  const useToast = () => {
+    const [toast, setToast] = useState(null);
 
-  useEffect(() => {
-    if (!toast) return undefined;
-    const timeout = setTimeout(() => setToast(null), toast.duration || DEFAULT_TIMEOUT);
-    return () => clearTimeout(timeout);
-  }, [toast]);
+    useEffect(() => {
+      if (!toast) return undefined;
+      const timeout = setTimeout(() => setToast(null), toast.duration || DEFAULT_TIMEOUT);
+      return () => clearTimeout(timeout);
+    }, [toast]);
 
-  const showToast = useCallback((nextToast) => {
-    setToast(normalizeToast(nextToast));
-  }, []);
+    const showToast = useCallback((nextToast) => {
+      setToast(normalizeToast(nextToast));
+    }, []);
 
-  const hideToast = useCallback(() => setToast(null), []);
+    const hideToast = useCallback(() => setToast(null), []);
 
-  return { toast, showToast, hideToast };
-};
+    return { toast, showToast, hideToast };
+  };
 
-window.MusicBee.hooks.useToast = useToast;
+  window.MusicBee.hooks.useToast = useToast;
+})();

--- a/public/app/main.jsx
+++ b/public/app/main.jsx
@@ -1,7 +1,9 @@
-window.MusicBee = window.MusicBee || {};
+(() => {
+  window.MusicBee = window.MusicBee || {};
 
-const { App } = window.MusicBee;
+  const { App } = window.MusicBee;
 
-const rootElement = document.getElementById('root');
-const root = ReactDOM.createRoot(rootElement);
-root.render(<App />);
+  const rootElement = document.getElementById('root');
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(<App />);
+})();

--- a/public/app/services/api.js
+++ b/public/app/services/api.js
@@ -1,95 +1,97 @@
-window.MusicBee = window.MusicBee || {};
-window.MusicBee.services = window.MusicBee.services || {};
+(() => {
+  window.MusicBee = window.MusicBee || {};
+  window.MusicBee.services = window.MusicBee.services || {};
 
-const { API_BASE } = window.MusicBee.constants;
+  const { API_BASE } = window.MusicBee.constants;
 
-const parseJSON = async (response) => {
-  const text = await response.text();
-  if (!text) return {};
-  try {
-    return JSON.parse(text);
-  } catch (error) {
-    console.warn('[api] Unable to parse JSON response', error);
-    return {};
-  }
-};
+  const parseJSON = async (response) => {
+    const text = await response.text();
+    if (!text) return {};
+    try {
+      return JSON.parse(text);
+    } catch (error) {
+      console.warn('[api] Unable to parse JSON response', error);
+      return {};
+    }
+  };
 
-const request = async (path, options = {}) => {
-  const response = await fetch(`${API_BASE}${path}`, options);
-  const data = await parseJSON(response);
-  if (!response.ok) {
-    const message = data?.message || `Errore ${response.status}`;
-    throw new Error(message);
-  }
-  return data;
-};
+  const request = async (path, options = {}) => {
+    const response = await fetch(`${API_BASE}${path}`, options);
+    const data = await parseJSON(response);
+    if (!response.ok) {
+      const message = data?.message || `Errore ${response.status}`;
+      throw new Error(message);
+    }
+    return data;
+  };
 
-const fetchCardsConfig = async () => {
-  const data = await request('/config');
-  if (!data.ok || !data.config || !data.config.cards) {
-    throw new Error(data.message || 'Configurazioni carte non disponibili');
-  }
-  return data.config.cards;
-};
+  const fetchCardsConfig = async () => {
+    const data = await request('/config');
+    if (!data.ok || !data.config || !data.config.cards) {
+      throw new Error(data.message || 'Configurazioni carte non disponibili');
+    }
+    return data.config.cards;
+  };
 
-const fetchCardsStatistics = async () => {
-  const data = await request('/cards/stats');
-  if (!data.ok || !data.statistics) {
-    throw new Error(data.message || 'Statistiche non disponibili');
-  }
-  return data.statistics;
-};
+  const fetchCardsStatistics = async () => {
+    const data = await request('/cards/stats');
+    if (!data.ok || !data.statistics) {
+      throw new Error(data.message || 'Statistiche non disponibili');
+    }
+    return data.statistics;
+  };
 
-const fetchPlayerStatus = async () => {
-  const data = await request('/player/status');
-  if (!data.ok) {
-    throw new Error(data.message || 'Stato player non disponibile');
-  }
-  return data.status || {};
-};
+  const fetchPlayerStatus = async () => {
+    const data = await request('/player/status');
+    if (!data.ok) {
+      throw new Error(data.message || 'Stato player non disponibile');
+    }
+    return data.status || {};
+  };
 
-const playCard = async (cardId) => {
-  const data = await request(`/cards/${encodeURIComponent(cardId)}/play`, {
-    method: 'POST'
+  const playCard = async (cardId) => {
+    const data = await request(`/cards/${encodeURIComponent(cardId)}/play`, {
+      method: 'POST'
+    });
+    if (!data.ok) {
+      throw new Error(data.message || 'Errore durante la riproduzione');
+    }
+    return data;
+  };
+
+  const deleteCard = async (cardId) => {
+    const data = await request(`/cards/${encodeURIComponent(cardId)}`, {
+      method: 'DELETE'
+    });
+    if (!data.ok) {
+      throw new Error(data.message || "Errore durante l'eliminazione");
+    }
+    return data;
+  };
+
+  const uploadCard = async ({ cardId, title, file }) => {
+    const formData = new FormData();
+    formData.append('title', title);
+    formData.append('audio', file);
+
+    const data = await request(`/cards/${encodeURIComponent(cardId)}/upload`, {
+      method: 'POST',
+      body: formData
+    });
+
+    if (!data.ok) {
+      throw new Error(data.message || 'Errore durante la configurazione della carta');
+    }
+
+    return data;
+  };
+
+  Object.assign(window.MusicBee.services, {
+    fetchCardsConfig,
+    fetchCardsStatistics,
+    fetchPlayerStatus,
+    playCard,
+    deleteCard,
+    uploadCard
   });
-  if (!data.ok) {
-    throw new Error(data.message || 'Errore durante la riproduzione');
-  }
-  return data;
-};
-
-const deleteCard = async (cardId) => {
-  const data = await request(`/cards/${encodeURIComponent(cardId)}`, {
-    method: 'DELETE'
-  });
-  if (!data.ok) {
-    throw new Error(data.message || "Errore durante l'eliminazione");
-  }
-  return data;
-};
-
-const uploadCard = async ({ cardId, title, file }) => {
-  const formData = new FormData();
-  formData.append('title', title);
-  formData.append('audio', file);
-
-  const data = await request(`/cards/${encodeURIComponent(cardId)}/upload`, {
-    method: 'POST',
-    body: formData
-  });
-
-  if (!data.ok) {
-    throw new Error(data.message || 'Errore durante la configurazione della carta');
-  }
-
-  return data;
-};
-
-Object.assign(window.MusicBee.services, {
-  fetchCardsConfig,
-  fetchCardsStatistics,
-  fetchPlayerStatus,
-  playCard,
-  deleteCard,
-  uploadCard
-});
+})();

--- a/public/app/utils/cards.js
+++ b/public/app/utils/cards.js
@@ -1,22 +1,24 @@
-window.MusicBee = window.MusicBee || {};
-window.MusicBee.utils = window.MusicBee.utils || {};
+(() => {
+  window.MusicBee = window.MusicBee || {};
+  window.MusicBee.utils = window.MusicBee.utils || {};
 
-const sortCardsByLastScan = (cardsMap) => {
-  return Object.entries(cardsMap)
-    .map(([cardId, card]) => ({ ...card, cardId }))
-    .sort((a, b) => {
-      const usageA = a.usage || {};
-      const usageB = b.usage || {};
-      const lastScanA = usageA.lastScannedAt
-        ? new Date(usageA.lastScannedAt).getTime()
-        : (a.updatedAt ? new Date(a.updatedAt).getTime() : 0);
-      const lastScanB = usageB.lastScannedAt
-        ? new Date(usageB.lastScannedAt).getTime()
-        : (b.updatedAt ? new Date(b.updatedAt).getTime() : 0);
-      return lastScanB - lastScanA;
-    });
-};
+  const sortCardsByLastScan = (cardsMap) => {
+    return Object.entries(cardsMap)
+      .map(([cardId, card]) => ({ ...card, cardId }))
+      .sort((a, b) => {
+        const usageA = a.usage || {};
+        const usageB = b.usage || {};
+        const lastScanA = usageA.lastScannedAt
+          ? new Date(usageA.lastScannedAt).getTime()
+          : (a.updatedAt ? new Date(a.updatedAt).getTime() : 0);
+        const lastScanB = usageB.lastScannedAt
+          ? new Date(usageB.lastScannedAt).getTime()
+          : (b.updatedAt ? new Date(b.updatedAt).getTime() : 0);
+        return lastScanB - lastScanA;
+      });
+  };
 
-Object.assign(window.MusicBee.utils, {
-  sortCardsByLastScan
-});
+  Object.assign(window.MusicBee.utils, {
+    sortCardsByLastScan
+  });
+})();

--- a/public/app/utils/format.js
+++ b/public/app/utils/format.js
@@ -1,43 +1,45 @@
-window.MusicBee = window.MusicBee || {};
-window.MusicBee.utils = window.MusicBee.utils || {};
+(() => {
+  window.MusicBee = window.MusicBee || {};
+  window.MusicBee.utils = window.MusicBee.utils || {};
 
-const formatRelative = (timestamp) => {
-  if (!timestamp) return '-';
-  const date = new Date(timestamp);
-  if (Number.isNaN(date.getTime())) return '-';
-  const now = new Date();
-  const diffMinutes = Math.floor((now - date) / (1000 * 60));
-  if (diffMinutes < 1) return 'Ora';
-  if (diffMinutes < 60) return `${diffMinutes}m fa`;
-  if (diffMinutes < 1440) return `${Math.floor(diffMinutes / 60)}h fa`;
-  return (
-    date.toLocaleDateString('it-IT') +
-    ' ' +
-    date.toLocaleTimeString('it-IT', { hour: '2-digit', minute: '2-digit' })
-  );
-};
+  const formatRelative = (timestamp) => {
+    if (!timestamp) return '-';
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return '-';
+    const now = new Date();
+    const diffMinutes = Math.floor((now - date) / (1000 * 60));
+    if (diffMinutes < 1) return 'Ora';
+    if (diffMinutes < 60) return `${diffMinutes}m fa`;
+    if (diffMinutes < 1440) return `${Math.floor(diffMinutes / 60)}h fa`;
+    return (
+      date.toLocaleDateString('it-IT') +
+      ' ' +
+      date.toLocaleTimeString('it-IT', { hour: '2-digit', minute: '2-digit' })
+    );
+  };
 
-const formatAbsolute = (timestamp) => {
-  if (!timestamp) return '--';
-  const date = new Date(timestamp);
-  if (Number.isNaN(date.getTime())) return '--';
-  return date.toLocaleString('it-IT', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
+  const formatAbsolute = (timestamp) => {
+    if (!timestamp) return '--';
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return '--';
+    return date.toLocaleString('it-IT', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit'
+    });
+  };
+
+  const formatNumber = (value) => {
+    if (value === null || value === undefined) return '--';
+    return new Intl.NumberFormat('it-IT').format(value);
+  };
+
+  Object.assign(window.MusicBee.utils, {
+    formatRelative,
+    formatAbsolute,
+    formatNumber
   });
-};
-
-const formatNumber = (value) => {
-  if (value === null || value === undefined) return '--';
-  return new Intl.NumberFormat('it-IT').format(value);
-};
-
-Object.assign(window.MusicBee.utils, {
-  formatRelative,
-  formatAbsolute,
-  formatNumber
-});
+})();


### PR DESCRIPTION
## Summary
- wrap the dashboard constants, utilities, hooks, services, and React components in IIFEs so their locals do not leak into the global scope
- wrap the main App bootstrapper to expose only the MusicBee namespace while keeping React hook aliases private
- ensure the Babel runtime no longer throws redeclaration errors for API constants, formatter helpers, or hooks when loading the dashboard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee42df650c8320b4c559380cc57d8a